### PR TITLE
ci: Build wheel for linux aarch64

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -458,6 +458,10 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v4
+      - name: Set CFLAGS for aarch64 on Ubuntu
+        if: matrix.os == 'ubuntu' && matrix.arch == 'aarch64'
+        run: |
+          echo "CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8" >> $GITHUB_ENV
       - name: Build sdist
         if: matrix.os == 'ubuntu' && matrix.arch == 'x64'
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -454,8 +454,6 @@ jobs:
         exclude:
           - os: windows
             arch: aarch64
-          - os: ubuntu
-            arch: aarch64
           - os: macos
             arch: x86
     steps:


### PR DESCRIPTION
taplo couldn't be run within dev container on mac m1 since it's using linux aarch64 bin which wasn't built

if this looks good i'll upstream this